### PR TITLE
Add Google calendar to events page

### DIFF
--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -5,3 +5,4 @@
 <li><a href="{{ site.baseurl }}/about-us">About us</a></li>
 <li><a href="{{ site.baseurl }}/join-us">Join us </a></li>
 <li><a href="{{ site.baseurl }}/resources">Resources </a></li>
+<li><a href="{{ site.baseurl }}/events">Events</a></li>

--- a/events/events.css
+++ b/events/events.css
@@ -11,7 +11,7 @@
     width: 100%;
 }
 
-.calendar-large {
+.calendar {
     margin-top: 30px;
     margin-bottom: 30px;
 }

--- a/events/events.css
+++ b/events/events.css
@@ -1,0 +1,44 @@
+.events-heading {
+    font-size: 45px;
+    margin-top: 0;
+}
+
+.events-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.calendar-large {
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.calendar-small {
+    display: none;
+}
+
+/* Mobile */
+@media only screen and (max-width: 800px) {
+    .calendar-large {
+        display: none;
+    }
+
+    .calendar-small {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        margin-top: 30px;
+        margin-bottom: 30px;
+    }
+}
+
+/* Desktop */
+@media only screen and (min-width: 800px) {
+    .calendar-small {
+        display: none;
+    }
+}

--- a/events/index.html
+++ b/events/index.html
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Events
+description: WICS events
+---
+
+<link rel="stylesheet" type="text/css" href="events.css">
+
+<div class="events-container">
+    <h2 class="events-heading"><b>Upcoming Events</b></h2>
+
+    <div class="calendar-large">
+        <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=uofmwics%40gmail.com&amp;color=%231B887A&amp;ctz=America%2FWinnipeg" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
+
+    <div class="calendar-small">
+        <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=uofmwics%40gmail.com&amp;color=%231B887A&amp;ctz=America%2FWinnipeg" style="border-width:0" width="80%" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
+</div>

--- a/events/index.html
+++ b/events/index.html
@@ -9,11 +9,11 @@ description: WICS events
 <div class="events-container">
     <h2 class="events-heading"><b>Upcoming Events</b></h2>
 
-    <div class="calendar-large">
+    <div class="calendar calendar-large">
         <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=uofmwics%40gmail.com&amp;color=%231B887A&amp;ctz=America%2FWinnipeg" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
     </div>
 
-    <div class="calendar-small">
+    <div class="calendar calendar-small">
         <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=uofmwics%40gmail.com&amp;color=%231B887A&amp;ctz=America%2FWinnipeg" style="border-width:0" width="80%" height="600" frameborder="0" scrolling="no"></iframe>
     </div>
 </div>


### PR DESCRIPTION
Desktop:
![image](https://user-images.githubusercontent.com/28549417/35307414-5031361e-0068-11e8-82df-36a19f83b870.png)

Mobile:
![image](https://user-images.githubusercontent.com/28549417/35307455-815ae71c-0068-11e8-93bc-fedb55e6ee94.png)

The colors aren't the prettiest but we can't really change them (but hey at least they match the WICS logo). Also on the `page/events` branch, @jbondoc has done some code for displaying photos/descriptions of past events under the calendar. I think that's a great idea, if we want to do that we can do it in another PR :)
