### PR TITLE
Improvement/join us/slack link

### DIFF
--- a/join-us/index.html
+++ b/join-us/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Join Us
+title: Tell us about yourself!
 description: link to our slack
 ---
 <div class="container">

--- a/join-us/index.html
+++ b/join-us/index.html
@@ -7,7 +7,7 @@ description: link to our slack
     <div class="row">
         <div class="col-md-3"></div>
         <div class="col-md-6">
-            <p style="font-size: 45px;" align="center"><b>Join Us</b></p>
+            <p style="font-size: 45px;" align="center"><b>Tell us about yourself!</b></p>
         </div>
     </div>
     <div class="row" style="margin-bottom: 30px;">


### PR DESCRIPTION
Changed the title of the 'Join Us' page to say 'Tell us about yourself!'

It's a minor change.

![screenshot 124](https://user-images.githubusercontent.com/19293725/35752549-fe38ca5e-0821-11e8-86ce-4d38f531fef2.png)
