### PR TITLE
Updated header/footer logos

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,9 +37,7 @@
                 <div class="nav navbar-nav navbar-left">
                     <p class="navbar-brand">University of Manitoba Women in Computer Science</p>
                 </div>
-
-                <a href="{{ site.baseurl }}/"><img alt="WICS Logo" src="{{ site.baseurl }}/assets/img/favicon/favicon-57.png"/></a>
-
+                
                 <ul class="nav navbar-nav navbar-right social-icons">
                     <li><a href="mailto:uofmwics@gmail.com" class="black-link"><span aria-label="Email" class="fa fa-envelope fa-2x"></span></a></li>
                     <li><a href="https://wicsuofm.slack.com/" class="black-link" target="_blank"><span aria-label="Slack" class="fa fa-slack fa-2x"></span></a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,19 +2,17 @@
     <nav class="navbar navbar-default navbar-custom">
         <div class="container">
             <div class="navbar-header">
+                <a href="{{ site.baseurl }}/"><img style=".img-fluid. max-width: 100%; height: 50px;" src="{{ site.baseurl }}/assets/img/favicon/favicon-310.png"/></a>
                 <!-- Dropdown menu button for smaller screens -->
                 <button type="button" data-target="#navbarCollapse" data-toggle="collapse" class="navbar-toggle collapsed">
                     <span class="sr-only">Toggle Navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
+                </button>
             </div>
             <!-- Navigation Links -->
-
             <div id="navbarCollapse" class="navbar-collapse collapse">
-                <div class="nav navbar-nav navbar-left">
-                    <a href="{{ site.baseurl }}/"><img style="height: 50px;" src="{{ site.baseurl }}/assets/img/favicon/favicon-310.png"/></a>
-                </div>
                 <ul class="nav navbar-nav navbar-right">
                     {% include nav-links.html %}
                 </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
 
             <div id="navbarCollapse" class="navbar-collapse collapse">
                 <div class="nav navbar-nav navbar-left">
-                    <a href="{{ site.baseurl }}/"><img style="height: 50px;" src="{{ site.baseurl }}/assets/img/favicon/favicon-60.png"/></a>
+                    <a href="{{ site.baseurl }}/"><img style="height: 50px;" src="{{ site.baseurl }}/assets/img/favicon/favicon-310.png"/></a>
                 </div>
                 <ul class="nav navbar-nav navbar-right">
                     {% include nav-links.html %}


### PR DESCRIPTION
Made the image in the header the larger version of the logo (so it does not appear pixelated), removed the logo in the footer (looks cleaner I think), and added the logo to the header on mobile.

![image](https://user-images.githubusercontent.com/19293725/37064591-30d1df50-2163-11e8-9700-f513c02f0191.png)

![image](https://user-images.githubusercontent.com/19293725/37064605-43fc99e4-2163-11e8-850d-3fdde77f226c.png)