### PR TITLE
Fixed modal close icon on co-op page. 

### DIFF
--- a/co-op/co-op.css
+++ b/co-op/co-op.css
@@ -21,5 +21,13 @@
     background: transparent;
 }
 .company-icon {
-        margin-top: 20px;
+    margin-top: 20px;
+}
+button.close{
+    float:right; 
+    transform-origin: center;
+    transform: scale(2);
+}
+button.close:focus {
+    outline: none;
 }

--- a/co-op/modal.html
+++ b/co-op/modal.html
@@ -2,7 +2,9 @@
 <div class="ui modal" id="{{ item.identification }}-modal">
     <div class="header">
         {{ item.title }}
-        <i id="{{ item.identification }}-close" style="float:right;" class="close icon"></i>
+        <button type="button" id="{{ item.identification }}-close" class="close" aria-label="Close">
+        	<span aria-hidden="true">&times;</span>
+        </button>
     </div>
     <div class="image content">
         <div class="ui small image">


### PR DESCRIPTION
Additionally, cleaned up inline CSS in modal.html.

Fixed by using a Bootstrap styled button attribute, instead of an icon attribute.