### PR TITLE
The entire footer of all co-op cards now displays modal

### DIFF
--- a/co-op/co-op.css
+++ b/co-op/co-op.css
@@ -30,7 +30,7 @@
 }
 
 .company-card-footer-link {
-    padding: 15px !important;
+    padding: 15px;
 }
 
 button.close {

--- a/co-op/co-op.css
+++ b/co-op/co-op.css
@@ -1,4 +1,4 @@
-.darkened{
+.darkened {
     filter: brightness(70%);
 }
 
@@ -20,10 +20,20 @@
     min-height: 60%;
     background: transparent;
 }
-.company-icon {
+
+.company-card {
     margin-top: 20px;
 }
-button.close{
+
+.company-card-footer {
+    padding: 0px !important;
+}
+
+.company-card-footer-link {
+    padding: 15px !important;
+}
+
+button.close {
     float:right; 
     transform-origin: center;
     transform: scale(2);

--- a/co-op/co-op.css
+++ b/co-op/co-op.css
@@ -26,11 +26,7 @@
 }
 
 .company-card-footer {
-    padding: 0px !important;
-}
-
-.company-card-footer-link {
-    padding: 15px;
+    padding: 5px;
 }
 
 button.close {

--- a/co-op/index.html
+++ b/co-op/index.html
@@ -59,7 +59,7 @@ description: Highlighting WICS members who have/had done a co-op
                             {% endif %}
                         </div>
                         <div class="content" style="padding: 0;">
-                            <a id="{{ item.identification }}" class="header" style="width: 100%; padding: 15px;">{{ item.title }}</a>
+                            <a id="{{ item.identification }}" class="header" style="padding: 15px;">{{ item.title }}</a>
                         </div>
                     </div>
                 </div>

--- a/co-op/index.html
+++ b/co-op/index.html
@@ -44,7 +44,7 @@ description: Highlighting WICS members who have/had done a co-op
         <div class="ui centered grid">
             {% for item in site.co-op-companies %}
             {% assign mod7 = forloop.index | modulo: 7 %}
-            <div class="col-md-2 company-icon">
+            <div class="company-card col-md-2">
                 <div class="ui link cards">
                     <div class="card">
                         <div class="blurring dimmable image">
@@ -58,8 +58,8 @@ description: Highlighting WICS members who have/had done a co-op
                             </a>
                             {% endif %}
                         </div>
-                        <div class="content" style="padding: 0;">
-                            <a id="{{ item.identification }}" class="header" style="padding: 15px;">{{ item.title }}</a>
+                        <div class="company-card-footer content">
+                            <a class="company-card-footer-link header" id="{{ item.identification }}">{{ item.title }}</a>
                         </div>
                     </div>
                 </div>

--- a/co-op/index.html
+++ b/co-op/index.html
@@ -58,8 +58,8 @@ description: Highlighting WICS members who have/had done a co-op
                             </a>
                             {% endif %}
                         </div>
-                        <div class="company-card-footer content">
-                            <a class="company-card-footer-link header" id="{{ item.identification }}">{{ item.title }}</a>
+                        <div class="company-card-footer content" id="{{ item.identification }}">
+                            <span class="header">{{ item.title }}</span>
                         </div>
                     </div>
                 </div>

--- a/co-op/index.html
+++ b/co-op/index.html
@@ -58,8 +58,8 @@ description: Highlighting WICS members who have/had done a co-op
                             </a>
                             {% endif %}
                         </div>
-                        <div class="content">
-                            <a id="{{ item.identification }}" class="header">{{ item.title }}</a>
+                        <div class="content" style="padding: 0;">
+                            <a id="{{ item.identification }}" class="header" style="width: 100%; padding: 15px;">{{ item.title }}</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Changed the padding on the footer elements of the cards listed on the co-op pages to invoke the modal, as some user clicks were not bringing up the modal due to the padding set on the <a> element and it's container.

# Current selection region
![CurrentSelectionRegion](https://user-images.githubusercontent.com/42011795/68079894-3027b400-fdbf-11e9-81a3-b66ee4843b67.png)

# New selection region
![NewSelectionRegion](https://user-images.githubusercontent.com/42011795/68079897-387fef00-fdbf-11e9-9b97-e067e47b8fc5.png)

