### PR TITLE
Bring back automatic deployment of the site

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if [ -z "$SSH_KEY" ]; then
+  echo "::error ::You need to set the SSH_KEY secret"
+  exit 1
+fi
+
+chmod 777 "$GITHUB_WORKSPACE"
+jekyll build
+
+KEY_FILE="$HOME/key"
+echo "$SSH_KEY" > "$KEY_FILE"
+chmod 400 "$KEY_FILE"
+rsync -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" -a --delete _site/ "$DESTINATION"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: docker://jekyll/jekyll:builder
         with:
           entrypoint: .github/workflows/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: docker://jekyll/jekyll:builder
+        with:
+          entrypoint: .github/workflows/deploy.sh
+        env:
+          DESTINATION: wics@aviary.cs.umanitoba.ca:~/public_html
+          SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Here's a much simpler alternative to the hilariously overengineered (but functional!) webhook work I did [here](https://github.com/umwics/deploy). I've tested this on my own server and it seems to be working.

cc: @shenyunw 

Steps for getting this to work:

1. Create an SSH key with `ssh-keygen`. Any Mac should have this command, and if not you can do it from one of the Linux lab (`aviary`) machines. Do not give the key a password. 
2. Log in `wics@aviary.cs.umanitoba.ca` and add the contents of the **public** key (`~/.ssh/id_rsa.pub` if you left the name as the default) on the machine that created the key to  `~/.ssh/authorized_keys` (on the `wics` account), on its own line.
3. Create a repository secret as described [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) called `SSH_KEY`, whose value is the contents of the **private** key (`~/.ssh/id_rsa`).

Once that's done, pushes to master should be deployed automatically.