### PR TITLE
move .title class to main.js

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -5,11 +5,8 @@ description: What does our student group do? What is computer science?
 ---
 
 <div class="container">
-    <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6">
-            <p style="font-size: 45px;" align="center"><b>About Us</b></p>
-        </div>
+    <div class="row title">
+        <p><b>About Us</b></p>
     </div>
 </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -200,7 +200,16 @@ body {
     font-size: 30px;
 }
 
+/* Page titles */
+
+.title {
+    text-align: center; 
+    margin-bottom: 1em;
+    font-size: 3.5em;
+}
+
 /* Container holding the image and the text */
+
 .img-container {
     position: relative;
     text-align: center;

--- a/co-op/index.html
+++ b/co-op/index.html
@@ -7,13 +7,10 @@ description: Highlighting WICS members who have/had done a co-op
 <link rel="stylesheet" type="text/css" href="co-op.css">
 
 <div class="container">
-    <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6">
-            <a style="font-size: 45px;" href="http://coop.cs.umanitoba.ca/" class="black-link" target="_blank">
-                <b>Computer Science Co-op</b>
-            </a>
-        </div>
+    <div class="row title">
+        <a style="font-size: 45px;" href="http://coop.cs.umanitoba.ca/" class="black-link" target="_blank">
+            <p><b>Computer Science Co-op</b></p>
+        </a>
     </div>
 </div>
 

--- a/events/index.html
+++ b/events/index.html
@@ -6,9 +6,13 @@ description: WICS events
 
 <link rel="stylesheet" type="text/css" href="events.css">
 
-<div class="events-container">
-    <h2 class="events-heading"><b>Upcoming Events</b></h2>
+<div class="container">
+    <div class="row title">
+        <p><b>Upcoming Events</b></p>
+    </div>
+</div>
 
+<div class="events-container">
     <div class="calendar calendar-large">
         <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=uofmwics%40gmail.com&amp;color=%231B887A&amp;ctz=America%2FWinnipeg" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
     </div>

--- a/execs/execs.css
+++ b/execs/execs.css
@@ -1,9 +1,3 @@
-.title {
-    text-align: center;
-    margin-bottom: 2em;
-    font-size: 3.5em;
-}
-
 .col-title {
     text-align: center;
     font-size: 1.5em;

--- a/execs/index.html
+++ b/execs/index.html
@@ -8,7 +8,7 @@ description: WICS Execs
 
 <div class="container">
     <div class="row title">
-        <b>WICS Execs</b>
+        <p><b>WICS Execs</b></p>
     </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -2,21 +2,15 @@
 layout: default
 ---
 <link rel="stylesheet" type="text/css" href="assets/css/main.css">
-<link rel="stylesheet" type="text/css" href="assets/css/carousel/flickity.css">
-
 
 <div class="container">
-    <div class="row">
-        <div class="col-md-1"></div>
-        <div class="col-md-10">
-            <p class="title"><b>U of M Women in Computer Science</b></p>
-            <div class="blink-block">
-                <p class="blink-text" align="center">We are
-                    <div class="blinking-cursor"></div>
-                </p>
-
-            </div>
-        </div>
+    <div class="row title">
+        <p><b>U of M Women in Computer Science</b></p>
+    </div>
+    <div class="blink-block">
+        <p class="blink-text">We are
+            <div class="blinking-cursor"></div>
+        </p>
     </div>
 </div>
 

--- a/join-us/index.html
+++ b/join-us/index.html
@@ -3,14 +3,12 @@ layout: default
 title: Join Us
 description: link to our slack
 ---
+
 <div class="container">
-    <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6">
-            <p style="font-size: 45px;" align="center"><b>Join Us</b></p>
-        </div>
+    <div class="row title">
+        <p><b>Join Us</b></p>
     </div>
-    <div class="row" style="margin-top: 15px; margin-bottom: 30px; text-align: center;">
+    <div class="row" style="margin-bottom: 30px; text-align: center;">
         <a href="https://wicsuofm.slack.com"><button class="ui primary button">Join Our Slack Here</button></a>
         <p style="text-align: center; margin-top:5px;font-size:15px;">This is where we discuss upcoming events, current news, and it's a chance to connect with other members!</p>
     </div>

--- a/resources/index.html
+++ b/resources/index.html
@@ -4,14 +4,10 @@ title: Resources
 description: things we recommend - e.g. tutorials
 ---
 <div class="container">
-    <div class="row">
-        <div class="col-md-3"></div>
-        <div class="col-md-6">
-            <p style="font-size: 45px;" align="center"><b>Resources</b></p>
-        </div>
+    <div class="row title">
+        <p><b>Resources</b></p>
     </div>
 </div>
-
 
 <div class="container">
 


### PR DESCRIPTION
Previously, the titles on all pages were inconsistent (some wrapped in p tags, inline vs. in the .css file, etc). 

To address this, the `.title` class was moved to the shared `main.css` file and all page title blocks were refactored. 

**Home**
[wHome](https://user-images.githubusercontent.com/46803874/72944266-0935aa00-3d3e-11ea-90c9-7946c9f6f07d.PNG)

**About Us**
![waboutus](https://user-images.githubusercontent.com/46803874/72944280-118de500-3d3e-11ea-9e31-2284d866d07d.PNG)

**Execs**
![wExecs](https://user-images.githubusercontent.com/46803874/72944387-603b7f00-3d3e-11ea-99ff-02c08711ed2b.PNG)

**Co-op**
![wCoop](https://user-images.githubusercontent.com/46803874/72944405-6893ba00-3d3e-11ea-9f2e-07914e9a67e4.PNG)

**Events**
![wEvents](https://user-images.githubusercontent.com/46803874/72944417-6fbac800-3d3e-11ea-97fa-cc5f007eef5a.PNG)

**Resources**
![wResources](https://user-images.githubusercontent.com/46803874/72944431-78130300-3d3e-11ea-89d0-662805824209.PNG)

**Join Us**
![wJoinUs](https://user-images.githubusercontent.com/46803874/72944437-7d704d80-3d3e-11ea-976e-bec4bd8217ae.PNG)
